### PR TITLE
Docs: README.md refactor for Netlify

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ yarn dev
 
 Open [http://localhost:4000](http://localhost:4000) with your browser to see the result.
 
-You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
+You can start editing the page by modifying `src/pages/index.tsx`. The page auto-updates as you edit the file.
 
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:4000/api/](http://localhost:4000/api/). This endpoint can be edited in `pages/api/*.ts`.
+[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:4000/api/](http://localhost:4000/api/). This endpoint can be edited in `src/pages/api/*.ts`.
 
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
+The `src/pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
 
 ### Frameworks
 
@@ -104,6 +104,6 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 
 This repo contains a unit testing that utilizes [Jest](https://jestjs.io/) and [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/). You can view the tests in the `__tests__` folder, and you can run the full test suite using the command below.
 
-```
+```sh
 npm run test
 ```


### PR DESCRIPTION
# Problem Context

The Netlify Deploy instructions were buried near the bottom of the README.md

## Changes

Refactor the README and add a Table of Contents (automatically created and updated by VSCode "Markdown All In One")
