### PR TITLE
refactor: Use 204 HTTP code when Sensor Config not found

### DIFF
--- a/__tests__/src/pages/api/sensorConfig.test.ts
+++ b/__tests__/src/pages/api/sensorConfig.test.ts
@@ -44,9 +44,9 @@
     expect(res.statusMessage).toEqual("OK");
   });
 
-  it("POST should return a 400 if Sensor Config is missing", async () => {
+  it("POST should return a 400 if Sensor MAC is missing", async () => {
     const {req, res} = mockRequestResponse("POST");
-    req.body = {}
+    req.body = {} // Equivalent to a null Sensor MAC
     await sensorConfigHandler(req, res);
 
     expect(res.statusCode).toBe(400);
@@ -57,13 +57,14 @@
     expect(res._getJSONData()).toEqual({ err: HTTP_STATUS.INVALID_CONFIG_BODY });
   });
  
-   it("should return a 404 if Sensor MAC is invalid", async () => {
+   it("should return a 204 if Sensor Config cannot be found", async () => {
      const {req, res} = mockRequestResponse();
-     req.query.macAddress = "hello_world";
+     // Pass a MAC address string that almost certainly won't exist
+     req.query.macAddress = "not_a_real_sensor_mac";
  
      await sensorConfigHandler(req, res);
  
-     expect(res.statusCode).toBe(404);
+     expect(res.statusCode).toBe(204);
      // eslint-disable-next-line no-underscore-dangle
      expect(res._getJSONData()).toEqual({ err: HTTP_STATUS.NOT_FOUND_CONFIG });
    });

--- a/src/pages/api/gateway/[gatewayUID]/sensor/[macAddress]/config.ts
+++ b/src/pages/api/gateway/[gatewayUID]/sensor/[macAddress]/config.ts
@@ -81,8 +81,8 @@ export default async function sensorConfigHandler (
       const { err } = response.data as NotehubErr;
       // Check the error message
       if (err.includes('note-noexist')) {
-        // Return 404 error
-        res.status(404).json({ err: HTTP_STATUS.NOT_FOUND_CONFIG });
+        // Return 204 error (request succeeded, but nothing to see here)
+        res.status(204).json({ err: HTTP_STATUS.NOT_FOUND_CONFIG });
         return;
       }
     } else {


### PR DESCRIPTION
# Problem Context
Our Sensor Config API endpoint currently returns a 404 when an invalid sensor MAC is passed, and the resulting config file is not found. This results in an exception being thrown and a chain of failures in the browser.

## Changes
This PR updates the Sensor Config API handler, and its unit test, to return a 204 instead when a Sensor Config cannot be found. A 204 HTTP response would indicate that 1. the request succeeded and 2. nothing to see here, and as a bonus it shouldn't throw an exception.

## Testing
- Run `yarn test` after pulling this branch
