### PR TITLE
fix: refreshes the page when the sensor details are edited. 

### DIFF
--- a/src/pages/[gatewayUID]/sensor/[sensorUID]/details.tsx
+++ b/src/pages/[gatewayUID]/sensor/[sensorUID]/details.tsx
@@ -33,6 +33,13 @@ const SensorDetails: NextPage<SensorDetailsData> = ({ viewModel, err }) => {
   const { TabPane } = Tabs;
   const { query } = useRouter();
 
+  const router = useRouter();
+  // Call this function whenever you want to
+  // refresh props!
+  const refreshData = () => {
+    router.replace(router.asPath);
+  }
+
   const formItems: FormProps[] = [
     {
       label: "Last Updated",
@@ -95,6 +102,10 @@ const SensorDetails: NextPage<SensorDetailsData> = ({ viewModel, err }) => {
       values
     );
     console.log(`Success: ${response}`);
+
+    if (response.status < 300) {
+      refreshData();
+    }
   };
 
   const formOnFinishFailed = (errorInfo: ValidateErrorEntity) => {


### PR DESCRIPTION
This is a quick fix for Beta, we can do better later with more targeted updates.

# Problem Context

After editing the sensor name, the name displayed at the top of the details page doesn't update. 

## Changes

After hitting "Save Changes" on the sensor details page, the page is refreshed to retrieve a new set of server side properties, which updates the sensor name at the top of the page.

## Screenshot (if applicable)

## Testing

Unit / integration / e2e tests?
* TBD:  I noticed the integration tests don't presently test the edit functionality on the sensor details page.

Steps to test manually?

1. Open the sensor details page by clicking on a sensor
2. Enter a name and location
3. Click "Save Changes"
4. In a while, the sensor name at the top of the page will refresh



## Any other related PRs

I imagine the appearance will be better when the spinner PR is integrated.  This feature should be tested with that to be sure the spinner appears as part of the redirect. 

Inspiration for this came from https://www.joshwcomeau.com/nextjs/refreshing-server-side-props/

## Ticket(s)

https://www.pivotaltracker.com/story/show/181159368

This addresses the "After updating the name/location it also updates in the sensor summary tab. "





