### PR TITLE
fix: to allow naming a node that has no name

### DIFF
--- a/src/services/notehub/NotehubAttributeStore.ts
+++ b/src/services/notehub/NotehubAttributeStore.ts
@@ -1,13 +1,20 @@
 import { AttributeStore } from "../AttributeStore";
+import NoteSensorConfigBody from "./models/NoteSensorConfigBody";
 import { NotehubAccessor } from "./NotehubAccessor";
 
 export class NotehubAttributeStore implements AttributeStore {
   constructor(private accessor: NotehubAccessor) {}
 
+  async getNodeConfig(gatewayUID: string, nodeID: string) {
+    const defaultConfig = {} as NoteSensorConfigBody;
+    const { body } = await this.accessor.getConfig(gatewayUID, nodeID);
+    return body || defaultConfig;
+  }
+
   async updateSensorName(gatewayUID: string, macAddress: string, name: string) {
-    const { body } = await this.accessor.getConfig(gatewayUID, macAddress);
-    body.name = name;
-    await this.accessor.setConfig(gatewayUID, macAddress, body);
+    const config = await this.getNodeConfig(gatewayUID, macAddress);
+    config.name = name;
+    await this.accessor.setConfig(gatewayUID, macAddress, config);
   }
 
   async updateSensorLocation(
@@ -15,9 +22,9 @@ export class NotehubAttributeStore implements AttributeStore {
     macAddress: string,
     loc: string
   ) {
-    const { body } = await this.accessor.getConfig(gatewayUID, macAddress);
-    body.loc = loc;
-    await this.accessor.setConfig(gatewayUID, macAddress, body);
+    const config = await this.getNodeConfig(gatewayUID, macAddress);
+    config.loc = loc;
+    await this.accessor.setConfig(gatewayUID, macAddress, config);
   }
 }
 


### PR DESCRIPTION
# Problem Context

trying to name a node which had no config (name nor location) led to a 500 error and failure to name the node.

## Changes

NotehubAttributeAccessor will properly fall-back on a default (empty) config now.

## Testing
- Pair a new node to your gateway
- Try to rename it in the web app.
=> Success

## Ticket(s)
https://www.pivotaltracker.com/story/show/181433693