### PR TITLE
chore: adds checks for required test environment variables

### DIFF
--- a/__tests__/src/TestConfig.ts
+++ b/__tests__/src/TestConfig.ts
@@ -1,0 +1,38 @@
+import Config from "../../config";
+
+const env = {
+    TEST_NODE_ID: process.env.TEST_NODE_ID,
+};
+  
+const optionalEnvVar = (varName: keyof typeof env, defaultValue: string) => {
+    const val = env[varName];
+    if (val === undefined) {
+      return defaultValue;
+    }
+    return val;
+};
+  
+const requiredEnvVar = (varName: keyof typeof env) => {
+    const val = env[varName];
+    if (val === undefined) {
+        throw new Error(
+        `${varName} is not set in the environment. See .env.local.example for help.`
+        );
+    }
+    return val;
+};
+
+const TestConfig = {
+    get testNodeId() {
+        return requiredEnvVar("TEST_NODE_ID");
+    },
+}
+
+
+describe("mandatory envvars are defined", () => {
+    it("TEST_NODE_ID", () => {
+        expect(TestConfig.testNodeId).toBeTruthy;
+    });
+});
+
+export default TestConfig;

--- a/__tests__/src/pages/api/nodeConfig.test.ts
+++ b/__tests__/src/pages/api/nodeConfig.test.ts
@@ -7,12 +7,13 @@ import { StatusCodes } from "http-status-codes";
 import nodeConfigHandler from "../../../../src/pages/api/gateway/[gatewayUID]/node/[nodeId]/config";
 import { HTTP_STATUS, HTTP_HEADER } from "../../../../src/constants/http";
 import { services } from "../../../../src/services/ServiceLocator";
+import TestConfig from "../../TestConfig";
 
 describe("/api/gateway/[gatewayUID]/node/[nodeId]/config API Endpoint", () => {
   const authToken = process.env.HUB_AUTH_TOKEN;
   const gatewayUIDs = process.env.HUB_DEVICE_UID;
   const gatewayUID = gatewayUIDs.split(",")[0];
-  const nodeId = process.env.TEST_NODE_ID;
+  const nodeId = TestConfig.testNodeId;
 
   function mockRequestResponse(method: RequestMethod = "GET") {
     const { req, res }: { req: NextApiRequest; res: NextApiResponse } =


### PR DESCRIPTION
# Problem Context

A missing `TEST_NODE_ID` causes the tests to fail in a non-obvious way. 

## Changes

Similar to `Config` we have `TestConfig` that captures the environment variables required during the test. 

## Screenshot (if applicable)

## Testing

Unit / integration / e2e tests?

* the existing CI tests will fail if the environment variable is not defined

## Any other related PRs

## Ticket(s)

- none. This was a quick fix. 