### PR TITLE
feat: live data reload - Proof of Concept

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -3,7 +3,7 @@ import { Layout } from "antd";
 import Header from "./Header";
 import Footer from "./Footer";
 import styles from "../../styles/Layout.module.scss";
-import { LoadingSpinner } from "./LoadingSpinner";
+import { LoadingMessage } from "./LoadingMessage";
 
 const LayoutComponent = ({
   children,
@@ -16,9 +16,8 @@ const LayoutComponent = ({
   return (
     <Layout>
       <Header />
-      <LoadingSpinner isLoading={isLoading}>
-        <Content className={styles.mainContent}>{children}</Content>
-      </LoadingSpinner>
+      <Content className={styles.mainContent}>{children}</Content>
+      <LoadingMessage isLoading={isLoading} />
       <Footer />
     </Layout>
   );

--- a/src/components/layout/LoadingMessage.tsx
+++ b/src/components/layout/LoadingMessage.tsx
@@ -1,0 +1,19 @@
+export const LoadingMessage = ({ isLoading }: { isLoading: boolean }) =>
+  isLoading ? (
+    <div
+      style={{
+        color: "white",
+        backgroundColor: "black",
+        position: "fixed",
+        bottom: "0",
+        right: "0",
+        zIndex: 100,
+        padding: "1em",
+      }}
+    >
+      Loading...
+    </div>
+  ) : null;
+
+const DEFAULT = { LoadingMessage };
+export default DEFAULT;

--- a/src/pages/[gatewayUID]/details.tsx
+++ b/src/pages/[gatewayUID]/details.tsx
@@ -25,7 +25,7 @@ const GatewayDetailsPage: NextPage<GatewayDetailsData> = ({
   const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
   const refreshData = async () => {
-    await router.replace(router.asPath);
+    await router.replace(router.asPath, undefined, { scroll: false });
   };
 
   const changeName = async (name: string) => {

--- a/src/pages/[gatewayUID]/node/[nodeId]/details.tsx
+++ b/src/pages/[gatewayUID]/node/[nodeId]/details.tsx
@@ -51,15 +51,19 @@ const NodeDetails: NextPage<NodeDetailsData> = ({ viewModel, err }) => {
   // Call this function whenever you want to
   // refresh props!
   const refreshData = async () => {
-    await router.replace(router.asPath);
+    await router.replace(router.asPath, undefined, { scroll: false });
   };
 
   const handleDateRangeChange = async (value: string) => {
     // call this function to force a page update with new chart date range
-    await router.replace({
-      pathname: `${nodeUrl}`,
-      query: { minutesBeforeNow: value },
-    });
+    await router.replace(
+      {
+        pathname: `${nodeUrl}`,
+        query: { minutesBeforeNow: value },
+      },
+      undefined,
+      { scroll: false }
+    );
   };
 
   const formItems: FormProps[] = [

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -15,7 +15,19 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
     Router.events.on("routeChangeStart", () => setIsLoading(true));
     Router.events.on("routeChangeComplete", () => setIsLoading(false));
     Router.events.on("routeChangeError", () => setIsLoading(false));
-  }, [Router.events]);
+
+    const unobtrusiveDataReload = () => {
+      Router.replace(window.location, undefined, { scroll: false }).catch(
+        () => {
+          throw new Error("Could not do unobtrusiveDataReload");
+        }
+      );
+    };
+    const i = setInterval(unobtrusiveDataReload, 7000);
+    const cleanup = () => clearInterval(i);
+
+    return cleanup;
+  }, [Router]);
 
   return (
     <>


### PR DESCRIPTION
# Problem Context

It's somewhat inconvenient for users to need to reload the page to see new data. That wouldn't work as a dashboard up on an office wall someplace.

## Changes

Use the NextJS Router to reload the page with client-side react-powered virtual DOM and reconciliation.

TODO:
- [ ] I'd like to remove all the `Router` stuff from our react components since `Router` is a NextJS concept and I really don't want the Sparrow web app to depend on NextJS any more than it absolutely needs to. However, I haven't thought of a way to pull it out since useRouter needs to be called from within each react component.

## Screenshot (if applicable)

![loadingpoc](https://user-images.githubusercontent.com/22032748/158470166-d2725558-e28c-4dd3-ba3f-ddb68b103f52.gif)


## Testing

Play around with it and see how well it works.

## Any other related PRs

## Ticket(s)
