### PR TITLE
spike: inline menu poc

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,14 @@
   "settings": {},
 
   // Add the IDs of extensions you want installed when the container is created.
-  "extensions": ["esbenp.prettier-vscode"],
+  "extensions": [
+    "esbenp.prettier-vscode",
+    "eamodio.gitlens",
+    "dbaeumer.vscode-eslint",
+    "ban.spellright",
+    "christian-kohler.path-intellisense",
+    "aaron-bond.better-comments"
+  ],
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   //"forwardPorts": [],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+// For format details, see https://aka.ms/devcontainer.json.
+{
+  "name": "Sparrow Reference Web App Development Dockerfile",
+
+  // Sets the run context to one level up instead of the .devcontainer folder.
+  "context": "..",
+
+  // Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+  "dockerFile": "../Dockerfile.dev",
+
+  // Set *default* container specific settings.json values on container create.
+  "settings": {},
+
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": ["esbenp.prettier-vscode"],
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  //"forwardPorts": [],
+  // Uncomment the next line to run commands after the container is created - for example installing curl.
+  // "postCreateCommand": "apt-get update && apt-get install -y curl",
+  // Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+  "runArgs": ["--net=host"],
+
+  // Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
+  // "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+  // Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "node"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "dev",
+      "options": {
+        "env": {
+            "HUB_DEVICE_UID": "",
+            "HUB_PROJECTUID": "",
+            "HUB_AUTH_TOKEN": ""
+        }
+      },
+      "problemMatcher": [],
+      "label": "Sparrow (local dev)",
+      "detail": "Launch with Target Project Values"
+    }
+  ]
+}

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,48 @@
+# Container for hosting dev.blues.io locally
+
+# Build development environment
+# $ docker build . --tag dev.blues.io
+
+# Launch development environment
+# $ docker run --interactive --net host --rm --tty \
+#   --volume $(pwd):/var/www/ dev.blues.io
+
+# Define global arguments
+ARG DEBIAN_FRONTEND="noninteractive"
+
+# Base Image
+FROM node:16.14-slim
+
+# Import global arguments
+ARG DEBIAN_FRONTEND
+
+# Execution Environment
+RUN ["dash", "-c", "\
+    apt-get update --quiet \
+ && apt-get install --assume-yes --no-install-recommends --quiet \
+      bash \
+      ca-certificates  `# for yarn install from git` \
+      git \
+      libasound2       `# for cypress` \
+      libgbm-dev       `# for cypress` \
+      libgconf-2-4     `# for cypress` \
+      libgtk2.0-0      `# for cypress` \
+      libgtk-3-0       `# for cypress` \
+      libnotify-dev    `# for cypress` \
+      libnss3          `# for cypress` \
+      libxss1          `# for cypress` \
+      libxtst6         `# for cypress` \
+      nano             `# for git commit --amend` \
+      ssh              `# for git push` \
+      xauth            `# for cypress` \
+      xvfb             `# for cypress` \
+ && apt-get clean \
+ && apt-get purge \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+"]
+
+# Runtime Environment
+WORKDIR /var/www/
+
+# Set default launch command
+CMD ["bash"]

--- a/cypress/integration/homepage.spec.js
+++ b/cypress/integration/homepage.spec.js
@@ -58,7 +58,7 @@ describe("Sparrow Application", () => {
     );
   });
 
-  it.only("should be able to click on a node card and see more details about that node and update the name and location of that node", function () {
+  it("should be able to click on a node card and see more details about that node and update the name and location of that node", function () {
     // this keeps uncaught exceptions from failing Cypress tests
     Cypress.on("uncaught:exception", (err, runnable) => {
       return false;

--- a/cypress/integration/homepage.spec.js
+++ b/cypress/integration/homepage.spec.js
@@ -58,7 +58,7 @@ describe("Sparrow Application", () => {
     );
   });
 
-  it("should be able to click on a node card and see more details about that node and update the name and location of that node", function () {
+  it.only("should be able to click on a node card and see more details about that node and update the name and location of that node", function () {
     // this keeps uncaught exceptions from failing Cypress tests
     Cypress.on("uncaught:exception", (err, runnable) => {
       return false;

--- a/package.json
+++ b/package.json
@@ -4,15 +4,15 @@
   "private": true,
   "scripts": {
     "genv": "./generate-dotenv.sh | tee .env.production.local",
-    "dev": "next dev -p 4000",
+    "dev": "yarn && next dev -p 4000",
     "build": "yarn genv; next build",
     "start": "next start",
     "lint": "next lint",
     "lint:all": "npx eslint . --ext .js,.jsx,.ts,.tsx",
     "test": "jest --watch",
     "test:coverage": "jest --coverage",
-    "cypress:open": "cypress open --env configFile=development",
-    "cypress:run": "cypress run --env configFile=development"
+    "cypress:open": "cypress install && cypress open --env configFile=development",
+    "cypress:run": "cypress install && cypress run --env configFile=development"
   },
   "dependencies": {
     "@ant-design/icons": "^4.7.0",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,6 +2,12 @@ import { useEffect, useState } from "react";
 import { AppProps } from "next/app";
 import Head from "next/head";
 import { useRouter } from "next/router";
+import { Menu } from "antd";
+import {
+  AppstoreOutlined,
+  MailOutlined,
+  SettingOutlined,
+} from "@ant-design/icons";
 import Layout from "../components/layout/Layout";
 import "../styles/globals.css";
 
@@ -11,11 +17,17 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
   const [isLoading, setIsLoading] = useState(false);
   const Router = useRouter();
 
+  const { SubMenu } = Menu;
+
   useEffect(() => {
     Router.events.on("routeChangeStart", () => setIsLoading(true));
     Router.events.on("routeChangeComplete", () => setIsLoading(false));
     Router.events.on("routeChangeError", () => setIsLoading(false));
   }, [Router.events]);
+
+  const handleClick = (e) => {
+    console.log("click ", e);
+  };
 
   return (
     <>
@@ -35,6 +47,41 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
           href="/favicon-16x16.png"
         />
       </Head>
+      <Menu
+        onClick={handleClick}
+        style={{ width: 256 }}
+        defaultSelectedKeys={["1"]}
+        defaultOpenKeys={["sub1"]}
+        mode="inline"
+      >
+        <SubMenu key="sub1" icon={<MailOutlined />} title="Navigation One">
+          <Menu.ItemGroup key="g1" title="Item 1">
+            <Menu.Item key="g1">Option 1</Menu.Item>
+            <Menu.Item key="2">Option 2</Menu.Item>
+          </Menu.ItemGroup>
+          <Menu.ItemGroup key="g2" title="Item 2">
+            <Menu.Item key="g2">Option 3</Menu.Item>
+            <Menu.Item key="4">Option 4</Menu.Item>
+          </Menu.ItemGroup>
+        </SubMenu>
+        <SubMenu key="sub2" icon={<AppstoreOutlined />} title="Navigation Two">
+          <Menu.Item key="5">Option 5</Menu.Item>
+          <Menu.Item key="6">Option 6</Menu.Item>
+          <SubMenu key="sub3" title="Submenu">
+            <Menu.Item key="7">Option 7</Menu.Item>
+            <Menu.Item key="8">Option 8</Menu.Item>
+          </SubMenu>
+        </SubMenu>
+        <SubMenu key="sub4" icon={<SettingOutlined />} title="Navigation Three">
+          <Menu.Item key="9">Option 9</Menu.Item>
+          <Menu.Item key="10">Option 10</Menu.Item>
+          <Menu.Item key="11">Option 11</Menu.Item>
+          <Menu.Item key="12">Option 12</Menu.Item>
+        </SubMenu>
+        <Menu.Item className="top-menu" key="13">
+          Option 13
+        </Menu.Item>
+      </Menu>
       <Layout isLoading={isLoading}>
         <Component {...pageProps} />
       </Layout>

--- a/src/styles/antd-variables.less
+++ b/src/styles/antd-variables.less
@@ -21,3 +21,7 @@
 @layout-header-color: #fff;
 @header-padding: 0 100px;
 @card-radius: 4px;
+
+@menu-bg: #fff;
+@menu-highlight-color: #10293c;
+@menu-inline-submenu-bg: #fff;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -14,3 +14,29 @@ a {
 * {
   box-sizing: border-box;
 }
+
+.ant-menu-item:hover {
+  background-color: #f3f3f3;
+}
+
+.ant-menu-submenu-title,
+.top-menu {
+  font-weight: 600;
+}
+
+.ant-menu-submenu-selected {
+  background-color: #e6fcff;
+}
+
+.ant-menu-item-selected {
+  background-color: #fff !important;
+}
+
+.ant-menu-inline .ant-menu-selected::after,
+.ant-menu-inline .ant-menu-item-selected::after {
+  transform: scaleY(1);
+  opacity: 1;
+  border-right: 3px solid #00b9ff !important;
+  transition: transform 0.15s cubic-bezier(0.645, 0.045, 0.355, 1),
+    opacity 0.15s cubic-bezier(0.645, 0.045, 0.355, 1);
+}


### PR DESCRIPTION
# Problem Context

This is a very hacky quick implementation I did to see if I could get the Ant Design inline menu to closely resemble how the Notehub menu looks and feels, at Michelle's request. With a little doing, it's possible and I showed her my efforts.

If you pick up the story to handle the menu redesign, please give this a reference as a starting point and reimplement it better than this hack job.

## Changes

## Screenshot (if applicable)

## Testing

Unit / integration / e2e tests?
Steps to test manually?
Any other sorts of testing notes to include?

## Any other related PRs

## Ticket(s)
