### PR TITLE
optional gateway voltage

### DIFF
--- a/__tests__/src/services/__serviceMocks__/sparrowData.json
+++ b/__tests__/src/services/__serviceMocks__/sparrowData.json
@@ -23,7 +23,7 @@
       "temperature": 22.6,
       "total": 281,
       "count": 1,
-      "bars": "0"
+      "bars": "N/A"
     },
     {
       "nodeId": "456789b",
@@ -33,7 +33,7 @@
       "pressure": 101.95,
       "temperature": 24.3,
       "count": 3,
-      "bars": "0"
+      "bars": "N/A"
     }
   ],
   "successfulNodeDataSparrowDataResponse": [

--- a/__tests__/src/services/notehub/NotehubDataProvider.test.ts
+++ b/__tests__/src/services/notehub/NotehubDataProvider.test.ts
@@ -14,6 +14,9 @@ import NotehubSensorConfig from "../../../../src/services/notehub/models/Notehub
 import NotehubResponse from "../../../../src/services/notehub/models/NotehubResponse";
 import Gateway from "../../../../src/services/alpha-models/Gateway";
 import Node from "../../../../src/services/alpha-models/Node";
+import IDBuilder from "../../../../src/services/IDBuilder";
+
+const mockProjectID = IDBuilder.buildProjectID("app:mockID");
 
 describe("Notehub data provider service functions", () => {
   const mockedGatewayJson =
@@ -42,7 +45,7 @@ describe("Notehub data provider service functions", () => {
       setConfig: jest.fn().mockResolvedValueOnce({}),
       setEnvironmentVariables: jest.fn().mockResolvedValueOnce({}),
     };
-    notehubDataProviderMock = new NotehubDataProvider(notehubAccessorMock);
+    notehubDataProviderMock = new NotehubDataProvider(notehubAccessorMock, mockProjectID);
   });
 
   it("should convert a Notehub device to a Sparrow gateway", async () => {

--- a/src/components/elements/GatewayCard.tsx
+++ b/src/components/elements/GatewayCard.tsx
@@ -20,8 +20,8 @@ const GatewayCardComponent = (props: GatewayProps) => {
   const { gatewayDetails, index } = props;
   const { Text } = Typography;
   const formattedGatewayVoltage = getFormattedVoltageData(
-    gatewayDetails.voltage
-  );
+    gatewayDetails.voltage===null ? undefined : gatewayDetails.voltage
+  ) || GATEWAY_MESSAGE.NO_VOLTAGE;
 
   const router = useRouter();
   const gatewayUrl = `/${gatewayDetails.uid}/details`;

--- a/src/components/presentation/gatewayDetails.ts
+++ b/src/components/presentation/gatewayDetails.ts
@@ -25,7 +25,7 @@ export function getGatewayDetailsPresentation(
           location: gateway.location || GATEWAY_MESSAGE.NO_LOCATION,
           name: gateway.name || GATEWAY_MESSAGE.NO_NAME,
           voltage:
-            getFormattedVoltageData(gateway.voltage) ||
+            getFormattedVoltageData(gateway.voltage===null ? undefined : gateway.voltage) ||
             GATEWAY_MESSAGE.NO_VOLTAGE,
           ...(gateway.cellBars && { cellBars: gateway.cellBars }),
           ...(gateway.cellBars

--- a/src/services/alpha-models/Gateway.ts
+++ b/src/services/alpha-models/Gateway.ts
@@ -13,7 +13,7 @@ interface Gateway {
   name: string;
   lastActivity: string;
   location?: string;
-  voltage: number;
+  voltage: number | null;
   /**
    * The signal strength for this gateway - either cell bars or wifi bars.
    */

--- a/src/services/notehub/NotehubDataProvider.ts
+++ b/src/services/notehub/NotehubDataProvider.ts
@@ -141,7 +141,7 @@ export default class NotehubDataProvider implements DataProvider {
     throw new Error("Method not implemented.");
   }
 
-  async getGateways() {
+  async getGateways() : Promise<GatewayDEPRECATED[]> {
     const gateways: GatewayDEPRECATED[] = [];
     const rawDevices = await this.notehubAccessor.getDevices();
     rawDevices.forEach((device) => {
@@ -150,7 +150,7 @@ export default class NotehubDataProvider implements DataProvider {
     return gateways;
   }
 
-  async getGateway(gatewayUID: string) {
+  async getGateway(gatewayUID: string): Promise<GatewayDEPRECATED> {
     const singleGatewayJson = await this.notehubAccessor.getDevice(gatewayUID);
 
     const singleGateway = notehubDeviceToSparrowGateway(singleGatewayJson);
@@ -291,7 +291,7 @@ export default class NotehubDataProvider implements DataProvider {
           total: gatewayNodeInfo.total,
         }),
         // todo replace this with real bars data once calculation to turn notecard data into bars is implemented
-        bars: "0" as SignalStrengths,
+        bars: "N/A" as SignalStrengths,
       };
     };
 

--- a/src/services/prisma-datastore/PrismaDataProvider.ts
+++ b/src/services/prisma-datastore/PrismaDataProvider.ts
@@ -51,7 +51,7 @@ function getGatewayVoltage(gw: GatewayWithLatestReadings): number | undefined {
     (sensor) => sensor.schema.name === "gateway_voltage"
   )[0];
   const value = voltageSensor?.latest?.value;
-  return value==undefined ? undefined : Number(value);
+  return value===undefined ? undefined : Number(value);
 }
 
 async function manageGatewayImport(

--- a/src/services/prisma-datastore/PrismaDataProvider.ts
+++ b/src/services/prisma-datastore/PrismaDataProvider.ts
@@ -46,11 +46,12 @@ import TemperatureSensorSchema from "../alpha-models/readings/TemperatureSensorS
 import TotalSensorSchema from "../alpha-models/readings/TotalSensorSchema";
 import PressureSensorSchema from "../alpha-models/readings/PressureSensorSchema";
 
-function getGatewayVoltage(gw: GatewayWithLatestReadings): number {
+function getGatewayVoltage(gw: GatewayWithLatestReadings): number | undefined {
   const voltageSensor = gw.readingSource.sensors.filter(
     (sensor) => sensor.schema.name === "gateway_voltage"
   )[0];
-  return Number(voltageSensor?.latest?.value || 0); // TODO Put a better default? Undefined?
+  const value = voltageSensor?.latest?.value;
+  return value==undefined ? undefined : Number(value);
 }
 
 async function manageGatewayImport(

--- a/src/services/prisma-datastore/db-init.ts
+++ b/src/services/prisma-datastore/db-init.ts
@@ -16,24 +16,6 @@ import {
 
 const prisma = new PrismaClient();
 
-// project
-//   hard-coded sensor schema (don't need so many)
-// factory project properties,
-//  factories for gateways
-//    factories for nodes (attributes)
-//       factories for sensor readings for a set of schema
-
-// default factories, and supplied factories, so individual elements can be overridden
-//
-
-// create a default schema. random number of everything
-// each mock data has one purpose?
-
-// project: no gateways
-
-// from the faker objects, we then run through and populate the project, create gateways in the project,
-// in prisma format.  Could have the mocker create the data in prisma format.
-//
 
 /**
  * Event processing:
@@ -309,10 +291,11 @@ const standardSchemas: BareReadingSchema[] = [
  * @param projectUID
  */
 async function createProject(prisma: PrismaClient, projectUID: string) {
+  console.log(`Creating project with PROJECT_UID ${projectUID}`);
   const project = await upsertProject({
     prisma,
     projectUID,
-    name: "typicalProject",
+    name: Config.companyName,
   });
   const schemas = standardSchemas.map(readingSchemaDefaults);
   await upsertReadingSchemas(prisma, project.readingSource, schemas);

--- a/src/services/prisma-datastore/prismaToSparrow.ts
+++ b/src/services/prisma-datastore/prismaToSparrow.ts
@@ -26,14 +26,14 @@ export type NodeWithLatestReadings = Prisma.Node & LatestReadingSourceReadings;
  */
 export function sparrowGatewayFromPrismaGateway(
   pGateway: Prisma.Gateway,
-  voltage: number
+  voltage?: number
 ): Gateway {
   return {
     uid: pGateway.deviceUID,
     name: pGateway.name || "", // todo - we will be reworking the Gateway/Sensor(Node) models. name should be optional
     location: pGateway.locationName || "",
     lastActivity: pGateway.lastSeenAt?.toString() || "", // todo - ideally this is simply cached
-    voltage,
+    voltage: voltage===undefined ? null : voltage,
     nodeList: [],
   };
 }


### PR DESCRIPTION
# Problem Context

When looking events on notehub.io `_session.qo` events from Gateways have a voltage property.  The notehub events retrieved via the API do not provide this property, and hence gateway voltage is not available.

## Changes

The primary change is to make the gateway voltage optional.  In the Gateway model, voltage is `nullable` rather than `optional` because `undefined` values generated in `getServerSideProps` do not serialize and generate a runtime error. Ideally `index.tsx` would use a view model like the details pages, but this work was not done in anticipation of using the reworked models that were originally planned for GA. 

Other changes:

* default bars from the notehub provider is "N/A"
* db-init.ts clean up.  Removed comments. Project name is set to the company name. 

