### PR TITLE
chore: removing gateway voltage from the app and adding am pm to chart timestamps

### DIFF
--- a/__tests__/src/components/elements/GatewayCard.test.tsx
+++ b/__tests__/src/components/elements/GatewayCard.test.tsx
@@ -10,7 +10,6 @@ const mockGatewayData = {
   uid: "My Mocked Gateway",
   name: "67890",
   location: "Gainesville, FL",
-  voltage: 3.7,
   lastActivity: "2022-01-05T07:36:55Z",
   nodeList: [
     {
@@ -32,7 +31,6 @@ const mockedGatewayDataLongName = {
   uid: "Another Mocked Gateway",
   name: "My Mocked Gateway With an Unbelievably Long Serial Number, Seriously You'll be Amazed",
   location: "San Diego, CA",
-  voltage: 4.0,
   lastActivity: "2022-02-11T08:48:01Z",
   nodeList: [],
 };
@@ -40,7 +38,6 @@ const mockedGatewayDataLongName = {
 const mockUndefinedGatewayData = {
   uid: "My Other Mocked Gateway",
   name: "13579",
-  voltage: 2.8,
   lastActivity: "2022-01-07T09:12:00Z",
   nodeList: [],
 };
@@ -57,9 +54,6 @@ describe("Gateway card component", () => {
         exact: false,
       })
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(mockGatewayData.voltage, { exact: false })
-    ).toBeInTheDocument();
   });
 
   it("should render the card when particular gateway data is missing", () => {
@@ -70,9 +64,6 @@ describe("Gateway card component", () => {
     expect(screen.getByText(mockUndefinedGatewayData.name)).toBeInTheDocument();
     expect(
       screen.getByText(GATEWAY_MESSAGE.NO_LOCATION, { exact: false })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(mockUndefinedGatewayData.voltage, { exact: false })
     ).toBeInTheDocument();
   });
 

--- a/cypress/integration/homepage.spec.js
+++ b/cypress/integration/homepage.spec.js
@@ -37,7 +37,6 @@ describe("Sparrow Application", () => {
     cy.get('[data-testid="gateway-location"]', { timeout: 90000 }).should(
       "be.visible"
     );
-    cy.get(".ant-card-body").should("contain", "Voltage");
     cy.get('[data-testid="gateway-last-seen"]').should("contain", "Last seen");
     // check for nodes related to gateway
     cy.get('[data-testid="gateway-node-header"]').should("contain", "Nodes");
@@ -117,10 +116,7 @@ describe("Sparrow Application", () => {
     nodeSubmitButton.should("be.visible");
     cy.get(".ant-form").submit();
     // Verify the node name is now updated to "Cypress Test Node"
-    cy.get('[data-testid="node-name"]').should(
-      "contain",
-      "Cypress Test Node"
-    );
+    cy.get('[data-testid="node-name"]').should("contain", "Cypress Test Node");
     // Enter a second new node name
     cy.get('[data-testid="form-input-node-name"]')
       .clear()
@@ -130,10 +126,7 @@ describe("Sparrow Application", () => {
     //Click the Submit button
     cy.get(".ant-form").submit();
     // Verify the node name is now updated to "Other Node Name"
-    cy.get('[data-testid="node-name"]').should(
-      "contain",
-      "Other Node Name"
-    );
+    cy.get('[data-testid="node-name"]').should("contain", "Other Node Name");
   });
 
   it.skip("should be able to paginate through the carousel for multiple gateways", function () {

--- a/src/components/charts/chartHelper.ts
+++ b/src/components/charts/chartHelper.ts
@@ -43,7 +43,7 @@ ChartJS.register(
 );
 
 // See https://date-fns.org/v2.27.0/docs/format
-export const CHART_DATE_FORMAT = "MMM do hh:mm";
+export const CHART_DATE_FORMAT = "MMM do hh:mm aa";
 
 export const GLOBAL_CHART_OPTIONS: ChartOptions<"line" | "bar"> = {
   responsive: true,

--- a/src/components/elements/FlexibleGatewayCard.tsx
+++ b/src/components/elements/FlexibleGatewayCard.tsx
@@ -2,10 +2,8 @@ import { useRouter } from "next/router";
 import { Card, Col, Row, Typography } from "antd";
 import NodeCard from "./FlexibleNodeCard";
 import {
-  asNumber,
   findCurrentReadingWithName,
   getFormattedLastSeenDate,
-  getFormattedVoltageData,
 } from "../presentation/uiHelpers";
 import { GATEWAY_MESSAGE, ERROR_MESSAGE } from "../../constants/ui";
 import { Gateway, GatewaySensorTypeNames } from "../../services/AppModel";
@@ -22,7 +20,6 @@ const GatewayCardComponent = (props: GatewayProps) => {
   const { index, gateway } = props;
   const { Text } = Typography;
 
-
   const router = useRouter();
   // todo - use urlBuilder to create the correct URL
   const gatewayUrl = `/${gateway.id.gatewayDeviceUID}/details`;
@@ -32,14 +29,9 @@ const GatewayCardComponent = (props: GatewayProps) => {
     router.push(gatewayUrl);
   };
 
-  
-  // we hard code some of the gateway readings for now. We will make this more open-ended in future with the site redesign
-  const formattedGatewayVoltage = getFormattedVoltageData(
-    asNumber(findCurrentReadingWithName(gateway, GatewaySensorTypeNames.VOLTAGE)?.reading?.value)
-) || GATEWAY_MESSAGE.NO_VOLTAGE;
-
-
-  const formattedLocation = findCurrentReadingWithName(gateway, GatewaySensorTypeNames.LOCATION) || GATEWAY_MESSAGE.NO_LOCATION;
+  const formattedLocation =
+    findCurrentReadingWithName(gateway, GatewaySensorTypeNames.LOCATION) ||
+    GATEWAY_MESSAGE.NO_LOCATION;
 
   return (
     <>
@@ -65,37 +57,26 @@ const GatewayCardComponent = (props: GatewayProps) => {
                 </Text>
                 <span className={cardStyles.timestamp}>
                   Last updated{` `}
-                  {gateway.lastSeen ? getFormattedLastSeenDate(new Date(gateway.lastSeen)) : GATEWAY_MESSAGE.NEVER_SEEN}
+                  {gateway.lastSeen
+                    ? getFormattedLastSeenDate(new Date(gateway.lastSeen))
+                    : GATEWAY_MESSAGE.NEVER_SEEN}
                 </span>
                 <div
                   data-testid="gateway-location"
                   className={cardStyles.locationWrapper}
                 >
-                  {/* todo - could have a LabelRenderer for a given sensor type/reading*/}
+                  {/* todo - could have a LabelRenderer for a given sensor type/reading */}
                   <span className={cardStyles.locationTitle}>
                     Location{` `}
-                  </span>                  
+                  </span>
                   <span className={cardStyles.location}>
                     {formattedLocation}
                   </span>
                 </div>
               </>
             }
-          >
-            <Row
-              justify="start"
-              gutter={[16, 16]}
-              className={cardStyles.cardContents}
-            >
-              <Col span={8}>
-                Voltage
-                <br />
-                <span className="dataNumber">{formattedGatewayVoltage}</span>
-              </Col>
-            </Row>
-          </Card>
+          />
         </Col>
-
       </Row>
 
       <h2 data-testid="node-header" className={styles.sectionSubTitle}>

--- a/src/components/elements/GatewayCard.tsx
+++ b/src/components/elements/GatewayCard.tsx
@@ -3,10 +3,7 @@ import Image from "next/image";
 import { Card, Col, Row, Tooltip, Typography } from "antd";
 import Gateway from "../../services/alpha-models/Gateway";
 import NodeCard from "./NodeCard";
-import {
-  getFormattedLastSeen,
-  getFormattedVoltageData,
-} from "../presentation/uiHelpers";
+import { getFormattedLastSeen } from "../presentation/uiHelpers";
 import { GATEWAY_MESSAGE, ERROR_MESSAGE } from "../../constants/ui";
 import styles from "../../styles/Home.module.scss";
 import cardStyles from "../../styles/Card.module.scss";
@@ -19,9 +16,6 @@ interface GatewayProps {
 const GatewayCardComponent = (props: GatewayProps) => {
   const { gatewayDetails, index } = props;
   const { Text } = Typography;
-  const formattedGatewayVoltage = getFormattedVoltageData(
-    gatewayDetails.voltage===null ? undefined : gatewayDetails.voltage
-  ) || GATEWAY_MESSAGE.NO_VOLTAGE;
 
   const router = useRouter();
   const gatewayUrl = `/${gatewayDetails.uid}/details`;
@@ -41,8 +35,7 @@ const GatewayCardComponent = (props: GatewayProps) => {
         <Col xs={24} sm={24} lg={12}>
           <Card
             headStyle={{ padding: "0" }}
-            bodyStyle={{ padding: "0" }}
-            className={cardStyles.cardStyle}
+            className={cardStyles.gatewayCardStyle}
             hoverable
             onClick={handleCardClick}
             title={
@@ -99,19 +92,7 @@ const GatewayCardComponent = (props: GatewayProps) => {
                 </span>
               </div>
             }
-          >
-            <Row
-              justify="start"
-              gutter={[16, 16]}
-              className={cardStyles.cardContents}
-            >
-              <Col span={8}>
-                Voltage
-                <br />
-                <span className="dataNumber">{formattedGatewayVoltage}</span>
-              </Col>
-            </Row>
-          </Card>
+          />
         </Col>
       </Row>
 

--- a/src/components/elements/GatewayDetails.tsx
+++ b/src/components/elements/GatewayDetails.tsx
@@ -87,14 +87,6 @@ const GatewayDetails = ({
                 </span>
               </Card>
             </Col>
-            <Col xs={12} sm={12} lg={8}>
-              <Card className={detailsStyles.card}>
-                <div className={detailsStyles.cardTitle}>Voltage</div>
-                <span className={detailsStyles.dataNumber}>
-                  {viewModel.gateway.voltage}
-                </span>
-              </Card>
-            </Col>
           </Row>
 
           {viewModel.nodes && viewModel.nodes.length > 0 ? (

--- a/src/components/presentation/gatewayDetails.ts
+++ b/src/components/presentation/gatewayDetails.ts
@@ -4,7 +4,6 @@ import {
   calculateSignalTooltip,
   calculateWifiSignalStrength,
   getFormattedLastSeen,
-  getFormattedVoltageData,
 } from "./uiHelpers";
 import { GATEWAY_MESSAGE } from "../../constants/ui";
 import Gateway from "../../services/alpha-models/Gateway";
@@ -24,9 +23,6 @@ export function getGatewayDetailsPresentation(
           lastActivity: getFormattedLastSeen(gateway.lastActivity || ""),
           location: gateway.location || GATEWAY_MESSAGE.NO_LOCATION,
           name: gateway.name || GATEWAY_MESSAGE.NO_NAME,
-          voltage:
-            getFormattedVoltageData(gateway.voltage===null ? undefined : gateway.voltage) ||
-            GATEWAY_MESSAGE.NO_VOLTAGE,
           ...(gateway.cellBars && { cellBars: gateway.cellBars }),
           ...(gateway.cellBars
             ? {

--- a/src/constants/ui.ts
+++ b/src/constants/ui.ts
@@ -32,7 +32,6 @@ const HISTORICAL_SENSOR_DATA_MESSAGE = {
 const GATEWAY_MESSAGE = {
   NO_NAME: "Unknown Gateway.",
   NO_LOCATION: "—",
-  NO_VOLTAGE: "—",
   NEVER_SEEN: "(never)",
 };
 

--- a/src/models/GatewayDetailViewModel.ts
+++ b/src/models/GatewayDetailViewModel.ts
@@ -7,7 +7,6 @@ interface GatewayDetailViewModel {
     name: string;
     lastActivity: string;
     location: string;
-    voltage: string;
     cellBars?: SignalStrengths;
     cellBarsIconPath?: string | null;
     cellBarsTooltip?: string | null;

--- a/src/pages/api/gateway/[gatewayUID]/node/[nodeId]/config.ts
+++ b/src/pages/api/gateway/[gatewayUID]/node/[nodeId]/config.ts
@@ -28,10 +28,6 @@ function validateRequest(
   res: NextApiResponse
 ): false | ValidRequest {
   const { gatewayUID, nodeId } = req.query;
-  // TODO: figure out what to do about this unsafe assignment of any. I really want runtime
-  // typechecking. All the code below feels terrible to write when we've already specified the API
-  // in typescript. Maybe we should really use a different language to specify the API and generate
-  // the typescript and typechecking code?
   const { name, location } = req.body as ValidRequest;
 
   if (typeof gatewayUID !== "string") {

--- a/src/pages/api/gateway/[gatewayUID]/node/[nodeId]/config.ts
+++ b/src/pages/api/gateway/[gatewayUID]/node/[nodeId]/config.ts
@@ -28,7 +28,7 @@ function validateRequest(
   res: NextApiResponse
 ): false | ValidRequest {
   const { gatewayUID, nodeId } = req.query;
-  // TODO (carl): figure out what to do about this unsafe assignment of any. I really want runtime
+  // TODO: figure out what to do about this unsafe assignment of any. I really want runtime
   // typechecking. All the code below feels terrible to write when we've already specified the API
   // in typescript. Maybe we should really use a different language to specify the API and generate
   // the typescript and typechecking code?

--- a/src/services/alpha-models/Gateway.ts
+++ b/src/services/alpha-models/Gateway.ts
@@ -13,7 +13,6 @@ interface Gateway {
   name: string;
   lastActivity: string;
   location?: string;
-  voltage: number | null;
   /**
    * The signal strength for this gateway - either cell bars or wifi bars.
    */

--- a/src/services/prisma-datastore/prismaToSparrow.ts
+++ b/src/services/prisma-datastore/prismaToSparrow.ts
@@ -25,15 +25,13 @@ export type NodeWithLatestReadings = Prisma.Node & LatestReadingSourceReadings;
  * @returns
  */
 export function sparrowGatewayFromPrismaGateway(
-  pGateway: Prisma.Gateway,
-  voltage?: number
+  pGateway: Prisma.Gateway
 ): Gateway {
   return {
     uid: pGateway.deviceUID,
     name: pGateway.name || "", // todo - we will be reworking the Gateway/Sensor(Node) models. name should be optional
     location: pGateway.locationName || "",
     lastActivity: pGateway.lastSeenAt?.toString() || "", // todo - ideally this is simply cached
-    voltage: voltage===undefined ? null : voltage,
     nodeList: [],
   };
 }
@@ -61,7 +59,7 @@ function findReading(
 }
 
 function asNumber(reading?: Prisma.Reading): number | undefined {
-  let result = undefined;
+  let result;
   if (typeof reading?.value === "number") {
     result = reading.value;
   }
@@ -69,7 +67,7 @@ function asNumber(reading?: Prisma.Reading): number | undefined {
 }
 
 function asString(reading?: Prisma.Reading): string | undefined {
-  let result = undefined;
+  let result;
   if (typeof reading?.value === "string") {
     result = reading.value;
   }

--- a/src/styles/Card.module.scss
+++ b/src/styles/Card.module.scss
@@ -1,6 +1,7 @@
 @import "_variables.scss";
 
-.cardStyle {
+.cardStyle,
+.gatewayCardStyle {
   margin: 5px 10px 5px 0;
   padding: 0 14px;
   box-shadow: 0px 1px 4px rgb(0 0 0 / 25%);
@@ -74,6 +75,12 @@
         font-size: 16px;
       }
     }
+  }
+}
+
+.gatewayCardStyle {
+  :global .ant-card-head {
+    border-bottom: none !important;
   }
 }
 


### PR DESCRIPTION
# Problem Context

We've decided to no longer include gateway voltage in the app's UI since it should always be USB powered (highly recommended anyway).

I also made Zak's requested change to add AM and PM indicators to the chart timestamps for easier reading.

## Changes

Remove all traces of gateway voltage from the frontend of the app and all display components.

Add AM / PM date formatting for charts.

## Screenshot (if applicable)

<img width="1149" alt="Screen Shot 2022-05-11 at 3 29 18 PM" src="https://user-images.githubusercontent.com/20400845/167930548-58fb6204-8a33-4768-b8ac-97bd2ab78732.png">

<img width="1150" alt="Screen Shot 2022-05-11 at 3 29 31 PM" src="https://user-images.githubusercontent.com/20400845/167930555-37c0933c-f343-4701-8e49-f98f812cdd29.png">

## Testing

Unit / integration / e2e tests?

Updated unit and e2e tests to prevent them breaking. 

Steps to test manually?

1. Go to http://localhost:4000
2. Note on the landing page, gateway cards now do not show voltage
3. Click on a gateway card, note that the gateway details page no longer shows voltage either.
4. Click on a node card
5. Note the node charts now show AM / PM timestamps instead of just times

Any other sorts of testing notes to include?

## Any other related PRs

n/a

## Ticket(s)

https://www.pivotaltracker.com/story/show/182145058
