### PR TITLE
notehub provider config

### DIFF
--- a/.github/workflows/CI-PRs-and-main.yml
+++ b/.github/workflows/CI-PRs-and-main.yml
@@ -37,6 +37,7 @@ jobs:
           HUB_BASE_URL: ${{ secrets.HUB_BASE_URL }}
           HUB_PROJECTUID: ${{ secrets.HUB_PROJECTUID }}
           TEST_NODE_ID: ${{ secrets.TEST_NODE_ID }}
+          NOTEHUB_PROVIDER: 1
         run: yarn test:coverage
       - run: yarn lint
       - name: Cypress run
@@ -49,6 +50,7 @@ jobs:
           HUB_BASE_URL: ${{ secrets.HUB_BASE_URL }}
           HUB_PROJECTUID: ${{ secrets.HUB_PROJECTUID }}
           TEST_NODE_ID: ${{ secrets.TEST_NODE_ID }}
+          NOTEHUB_PROVIDER: 1
   docker-build:
     runs-on: ubuntu-latest
     steps:

--- a/config.ts
+++ b/config.ts
@@ -16,6 +16,7 @@ const env = {
   NEXT_PUBLIC_COMPANY_NAME: process.env.NEXT_PUBLIC_COMPANY_NAME,
   DATABASE_URL: process.env.DATABASE_URL,
   READ_ONLY: process.env.READ_ONLY,
+  NOTEHUB_PROVIDER: process.env.NOTEHUB_PROVIDER
 };
 
 const optionalEnvVar = (varName: keyof typeof env, defaultValue: string) => {
@@ -60,11 +61,15 @@ const Config = {
     return optionalEnvVar("HUB_GUI_URL", "https://notehub.io");
   },
   get databaseURL() {
-    return optionalEnvVar("DATABASE_URL", "");
+    const getVar = this.notehubProvider ? optionalEnvVar : requiredEnvVar;
+    return getVar("DATABASE_URL", "");
   },
   get readOnly() {
     return Boolean(optionalEnvVar("READ_ONLY", ""));
   },
+  get notehubProvider() {
+    return Boolean(optionalEnvVar("NOTEHUB_PROVIDER", ""));
+  }
 };
 
 const toString = (c: typeof Config | typeof env) => {

--- a/src/services/ServiceLocator.ts
+++ b/src/services/ServiceLocator.ts
@@ -48,8 +48,8 @@ class ServiceLocator {
     this.prisma = !notehubProvider
       ? getPrismaClient(databaseURL)
       : undefined;
-    const msg = this.prisma ? `Connecting to database at ${databaseURL}` : 'Using Notehub provider';
-    serverLogInfo(msg);
+    const message = this.prisma ? `Connecting to database at ${databaseURL}` : 'Using Notehub provider';
+    serverLogInfo(message);
   }
 
   getAppService(): AppServiceInterface {

--- a/src/services/ServiceLocator.ts
+++ b/src/services/ServiceLocator.ts
@@ -20,6 +20,7 @@ import CompositeDataProvider from "./prisma-datastore/CompositeDataProvider";
 import PrismaAttributeStore from "./prisma-datastore/PrismaAttributeStore";
 import CompositeAttributeStore from "./prisma-datastore/CompositeAttributeStore";
 import { getPrismaClient } from "./prisma-datastore/prisma-util";
+import { serverLogInfo, serverLogProgress } from "../pages/api/log";
 
 // ServiceLocator is the top-level consturction and dependency injection tool
 // for client-side (browser-side) and also server-side node code. It uses lazy
@@ -42,9 +43,13 @@ class ServiceLocator {
   private eventHandler?: SparrowEventHandler;
 
   constructor() {
-    this.prisma = Config.databaseURL
-      ? getPrismaClient(Config.databaseURL)
+    const notehubProvider = Config.notehubProvider;
+    const databaseURL = Config.databaseURL;
+    this.prisma = !notehubProvider
+      ? getPrismaClient(databaseURL)
       : undefined;
+    const msg = this.prisma ? `Connecting to database at ${databaseURL}` : 'Using Notehub provider';
+    serverLogInfo(msg);
   }
 
   getAppService(): AppServiceInterface {


### PR DESCRIPTION
# Problem Context

Adds an optional environment variable `NOTEHUB_PROVIDER`. When not set, or set to a falsy value, the prisma provider is used and `DATABASE_URL` is required. When set to a truthy value,`DATABASE_URL` is not required and the notehub provider is used. 

The notehub provider is intended for development purposes only and is not suitable for production use.

## Changes

* Adds a new Config variable `NOTEHUB_PROVIDER` with the default value of 0
* `DATABASE_URL` is required when `NOTEHUB_PROVIDER` is not set to a truthy value. 
* ServiceLocator uses these variables to determine which provider to use.  It outputs an info server log showing the provider in use. 
