### PR TITLE
fix: Node details should default to 24 hours of data

### DIFF
--- a/src/pages/[gatewayUID]/node/[nodeId]/details.tsx
+++ b/src/pages/[gatewayUID]/node/[nodeId]/details.tsx
@@ -39,6 +39,8 @@ type NodeDetailsData = {
   err?: string;
 };
 
+const DEFAULT_MINUTES_BEFORE_NOW = "1440";
+
 const NodeDetails: NextPage<NodeDetailsData> = ({ viewModel, err }) => {
   const { TabPane } = Tabs;
   const { Option } = Select;
@@ -275,7 +277,7 @@ const NodeDetails: NextPage<NodeDetailsData> = ({ viewModel, err }) => {
                     defaultValue={
                       query.minutesBeforeNow
                         ? query.minutesBeforeNow.toString()
-                        : "1440"
+                        : DEFAULT_MINUTES_BEFORE_NOW
                     }
                     style={{ width: "100%" }}
                     onChange={handleDateRangeChange}
@@ -429,7 +431,7 @@ export const getServerSideProps: GetServerSideProps<NodeDetailsData> = async ({
     const readings = await appService.getNodeData(
       gatewayUID,
       nodeId,
-      Number(minutesBeforeNow)
+      Number(minutesBeforeNow || DEFAULT_MINUTES_BEFORE_NOW)
     );
 
     viewModel = getNodeDetailsPresentation(node, gateway, readings);


### PR DESCRIPTION
# Problem Context

The node details page determines how much data to load based off its `minutesBeforeNow` query string parameter. When that value is not present, we previously defaulted to an environment variable to determine the default value.

When we removed the environment variable, there was no longer any fallback, and the node details page would load ALL THE DATA by default. Oops.

## Changes

We now pass a default date to the service when one is not in the query string.

## Testing

Load the node details page with no query string. You should see one day’s worth of readings.
