### PR TITLE
fix: refactoring to use both a client- and server-side ServiceLocator

### DIFF
--- a/__tests__/src/pages/api/gatewayName.test.ts
+++ b/__tests__/src/pages/api/gatewayName.test.ts
@@ -6,7 +6,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { createMocks, RequestMethod } from "node-mocks-http";
 import gatewayNameHandler from "../../../../src/pages/api/gateway/[gatewayUID]/name";
 import { HTTP_STATUS, HTTP_HEADER } from "../../../../src/constants/http";
-import { services } from "../../../../src/services/ServiceLocator";
+import { services } from "../../../../src/services/ServiceLocatorServer";
 
 const authToken = process.env.HUB_AUTH_TOKEN;
 

--- a/__tests__/src/pages/api/nodeConfig.test.ts
+++ b/__tests__/src/pages/api/nodeConfig.test.ts
@@ -6,7 +6,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { StatusCodes } from "http-status-codes";
 import nodeConfigHandler from "../../../../src/pages/api/gateway/[gatewayUID]/node/[nodeId]/config";
 import { HTTP_STATUS, HTTP_HEADER } from "../../../../src/constants/http";
-import { services } from "../../../../src/services/ServiceLocator";
+import { services } from "../../../../src/services/ServiceLocatorServer";
 import TestConfig from "../../TestConfig";
 
 describe("/api/gateway/[gatewayUID]/node/[nodeId]/config API Endpoint", () => {

--- a/src/api-client/bulkDataImport.ts
+++ b/src/api-client/bulkDataImport.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { BulkDataImportStatus } from "../services/AppModel";
-import { services } from "../services/ServiceLocator";
+import { services } from "../services/ServiceLocatorClient";
 
 export async function performBulkDataImport() {
   const endpoint = services().getUrlManager().performBulkDataImportApi();

--- a/src/api-client/gateway.ts
+++ b/src/api-client/gateway.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosResponse } from "axios";
-import { services } from "../services/ServiceLocator";
+import { services } from "../services/ServiceLocatorServer";
 
 export async function changeGatewayName(gatewayUID: string, name: string) {
   const endpoint = services().getUrlManager().gatewayNameUpdate(gatewayUID);

--- a/src/api-client/node.ts
+++ b/src/api-client/node.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosResponse } from "axios";
-import { services } from "../services/ServiceLocator";
+import { services } from "../services/ServiceLocatorServer";
 
 export async function changeNodeName(
   gatewayUID: string,

--- a/src/pages/[gatewayUID]/details.tsx
+++ b/src/pages/[gatewayUID]/details.tsx
@@ -6,7 +6,7 @@ import { useState } from "react";
 import { changeGatewayName } from "../../api-client/gateway";
 import GatewayDetails from "../../components/elements/GatewayDetails";
 import { LoadingSpinner } from "../../components/layout/LoadingSpinner";
-import { services } from "../../services/ServiceLocator";
+import { services } from "../../services/ServiceLocatorServer";
 import { getErrorMessage } from "../../constants/ui";
 import { ERROR_CODES } from "../../services/Errors";
 

--- a/src/pages/[gatewayUID]/node/[nodeId]/details.tsx
+++ b/src/pages/[gatewayUID]/node/[nodeId]/details.tsx
@@ -13,7 +13,7 @@ import {
   HISTORICAL_SENSOR_DATA_MESSAGE,
   NODE_MESSAGE,
 } from "../../../../constants/ui";
-import { services } from "../../../../services/ServiceLocator";
+import { services } from "../../../../services/ServiceLocatorServer";
 import NodeDetailsLineChart from "../../../../components/charts/NodeDetailsLineChart";
 import NodeDetailsBarChart from "../../../../components/charts/NodeDetailsBarChart";
 import NodeDetailViewModel from "../../../../models/NodeDetailViewModel";

--- a/src/pages/admin.tsx
+++ b/src/pages/admin.tsx
@@ -2,7 +2,7 @@ import { GetServerSideProps, NextPage } from "next";
 import Title from "antd/lib/typography/Title";
 import Link from "next/link";
 import { Breadcrumb, Card, Space } from "antd";
-import { services } from "../services/ServiceLocator";
+import { services } from "../services/ServiceLocatorServer";
 import { getErrorMessage } from "../constants/ui";
 import { ERROR_CODES, isError, MayError } from "../services/Errors";
 import { Project } from "../services/AppModel";

--- a/src/pages/api/admin/bulk-data-import.ts
+++ b/src/pages/api/admin/bulk-data-import.ts
@@ -2,7 +2,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { ReasonPhrases, StatusCodes } from "http-status-codes";
 import { ErrorWithCause } from "pony-cause";
-import { services } from "../../../services/ServiceLocator";
+import { services } from "../../../services/ServiceLocatorServer";
 import { BulkDataImportStatus } from "../../../services/AppModel";
 import { serverLogError } from "../log";
 

--- a/src/pages/api/datastore/ingest.ts
+++ b/src/pages/api/datastore/ingest.ts
@@ -3,7 +3,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { HTTP_STATUS } from "../../../constants/http";
 import NotehubRoutedEvent from "../../../services/notehub/models/NotehubRoutedEvent";
 import { sparrowEventFromNotehubRoutedEvent } from "../../../services/notehub/SparrowEvents";
-import { services } from "../../../services/ServiceLocator";
+import { services } from "../../../services/ServiceLocatorServer";
 import { serverLogInfo } from "../log";
 
 async function ingestEvent(notehubEvent: NotehubRoutedEvent) {

--- a/src/pages/api/gateway/[gatewayUID]/name.ts
+++ b/src/pages/api/gateway/[gatewayUID]/name.ts
@@ -3,7 +3,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { ReasonPhrases, StatusCodes } from "http-status-codes";
 import { ErrorWithCause } from "pony-cause";
 
-import { services } from "../../../../services/ServiceLocator";
+import { services } from "../../../../services/ServiceLocatorServer";
 import { HTTP_STATUS } from "../../../../constants/http";
 import { serverLogError } from "../../log";
 

--- a/src/pages/api/gateway/[gatewayUID]/node/[nodeId]/config.ts
+++ b/src/pages/api/gateway/[gatewayUID]/node/[nodeId]/config.ts
@@ -3,7 +3,7 @@ import { ErrorWithCause } from "pony-cause";
 import { ReasonPhrases, StatusCodes } from "http-status-codes";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { services } from "../../../../../../services/ServiceLocator";
+import { services } from "../../../../../../services/ServiceLocatorServer";
 import { HTTP_STATUS } from "../../../../../../constants/http";
 import { serverLogError } from "../../../../log";
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,7 +3,7 @@ import { GetServerSideProps, NextPage } from "next";
 import { Carousel } from "antd";
 import { CarouselRef } from "antd/lib/carousel";
 import GatewayCard from "../components/elements/GatewayCard";
-import { services } from "../services/ServiceLocator";
+import { services } from "../services/ServiceLocatorServer";
 import Gateway from "../services/alpha-models/Gateway";
 import Node from "../services/alpha-models/Node";
 import { ERROR_MESSAGE, getErrorMessage } from "../constants/ui";

--- a/src/presentation/BulkDataImport.ts
+++ b/src/presentation/BulkDataImport.ts
@@ -1,5 +1,5 @@
 import { BulkDataImportStatus } from "../services/AppModel";
-import { services } from "../services/ServiceLocator";
+import { services } from "../services/ServiceLocatorServer";
 
 export type BulkDataImportViewModel = {
   readingCount: string;

--- a/src/services/ServiceLocatorClient.ts
+++ b/src/services/ServiceLocatorClient.ts
@@ -1,0 +1,27 @@
+import { UrlManager } from "../components/presentation/UrlManager";
+import { NextJsUrlManager } from "../adapters/nextjs-sparrow/NextJsUrlManager";
+
+class ServiceLocatorClient {
+  private urlManager?: UrlManager;
+
+  getUrlManager(): UrlManager {
+    if (!this.urlManager) {
+      this.urlManager = NextJsUrlManager;
+    }
+    return this.urlManager;
+  }
+}
+
+let Services: ServiceLocatorClient | null = null;
+
+function services() {
+  // Don’t create a ServiceLocator until it’s needed. This prevents all service
+  // initialization steps from happening as soon as you import this module.
+  if (!Services) {
+    Services = new ServiceLocatorClient();
+  }
+  return Services;
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export { services };

--- a/src/services/ServiceLocatorServer.ts
+++ b/src/services/ServiceLocatorServer.ts
@@ -20,14 +20,11 @@ import CompositeDataProvider from "./prisma-datastore/CompositeDataProvider";
 import PrismaAttributeStore from "./prisma-datastore/PrismaAttributeStore";
 import CompositeAttributeStore from "./prisma-datastore/CompositeAttributeStore";
 import { getPrismaClient } from "./prisma-datastore/prisma-util";
-import { serverLogInfo, serverLogProgress } from "../pages/api/log";
+import { serverLogInfo } from "../pages/api/log";
 
 // ServiceLocator is the top-level consturction and dependency injection tool
-// for client-side (browser-side) and also server-side node code. It uses lazy
-// instanciation because some of these services are invalid to use browser-side.
-// Trying to instanciate them there would just throw an error about undefined
-// secret environment variables.
-class ServiceLocator {
+// for server-side node code.
+class ServiceLocatorServer {
   private appService?: AppServiceInterface;
 
   private urlManager?: UrlManager;
@@ -45,10 +42,10 @@ class ServiceLocator {
   constructor() {
     const notehubProvider = Config.notehubProvider;
     const databaseURL = Config.databaseURL;
-    this.prisma = !notehubProvider
-      ? getPrismaClient(databaseURL)
-      : undefined;
-    const message = this.prisma ? `Connecting to database at ${databaseURL}` : 'Using Notehub provider';
+    this.prisma = !notehubProvider ? getPrismaClient(databaseURL) : undefined;
+    const message = this.prisma
+      ? `Connecting to database at ${databaseURL}`
+      : "Using Notehub provider";
     serverLogInfo(message);
   }
 
@@ -141,13 +138,13 @@ class ServiceLocator {
   }
 }
 
-let Services: ServiceLocator | null = null;
+let Services: ServiceLocatorServer | null = null;
 
 function services() {
   // Don’t create a ServiceLocator until it’s needed. This prevents all service
   // initialization steps from happening as soon as you import this module.
   if (!Services) {
-    Services = new ServiceLocator();
+    Services = new ServiceLocatorServer();
   }
   return Services;
 }


### PR DESCRIPTION
# Problem Context

Fixing an issue where the bulk data import was crashing because it didn’t tried to use the `ServiceLocator`, which had logic added in ed686a91c369cb5d0cf01992a033220ac9bf975f which made it only run successfully on the server.

## Changes

These sort of problems have came up before, so we decided to create a separate client-side `ServiceLocator`, for client-side only usage.

## Testing

Running a bulk import tests the specific problem this PR addresses. And the test suite so help catch any import mistakes.

