### PR TITLE
build(deps): bump moment from 2.29.2 to 2.29.4

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4522,9 +4522,9 @@ moize@^6.1.0:
     micro-memoize "^4.0.9"
 
 moment@^2.24.0, moment@^2.25.3:
-  version "2.29.2"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.2.tgz#00910c60b20843bcba52d37d58c628b47b1f20e4"
-  integrity sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
 
 mri@^1.1.6:
   version "1.2.0"


### PR DESCRIPTION
# Problem Context

This change was suggested by dependabot, but it seems to fail because of a missing env var (`HUB_PROJECTUID`).  I'm not aware the environment has changed, so I'm curious if this is because it's a dependabot PR (the PR is not sourced from this repo and doesn't have access to our secrets.)

https://github.com/blues/sparrow-reference-web-app/security/dependabot/23

## Changes

yarn.lock version and SHA change for moment

## Testing

CI build.

I will manually test the entire webapp if this is successful.

