### PR TITLE
fix(devcontainer): expose port 4000 in the devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,5 +36,8 @@
   // Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
   // "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
   // Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
-  "remoteUser": "node"
+  "remoteUser": "node",
+
+  // forward the default port the app runs on so we can see it from the host OS
+  "forwardPorts": [4000]
 }


### PR DESCRIPTION


# Problem Context

Running on OS X, port 4000 wasn't exposed from the devcontainer to the host

## Changes

Expose port 4000

## Testing

1. open the project in VSCode locally, then choose "Reopen in container"
2. run `yarn dev`
3. browse to `localhost:4000` - the webapp should appear. 

