### PR TITLE
fix: prisma db push during deploy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,5 +13,5 @@
   DEBUG_CONFIG = "(optional) Debug config? If not '', log environment and config on server"
 
 [context.production]
-  command = "sed -i \"s|process.env.DEPLOY_URL|'${DEPLOY_URL}'|g\" config.ts && yarn build && yarn db:update && yarn db:init"
+  command = "sed -i \"s|process.env.DEPLOY_URL|'${DEPLOY_URL}'|g\" config.ts && yarn build && yarn run prisma db push --accept-data-loss && yarn db:init"
   


### PR DESCRIPTION
# Problem Context

prisma generates warnings about unique constraints being added when running `db push`.  These warnings are bogus.

```
2:47:01 PM:   • A unique constraint covering the columns `[uuid]` on the table `reading_schema` will be added. If there are existing duplicate values, this will fail.
2:47:01 PM:   • A unique constraint covering the columns `[name]` on the table `reading_schema` will be added. If there are existing duplicate values, this will fail.
2:47:01 PM:   • A unique constraint covering the columns `[latest_id]` on the table `sensor` will be added. If there are existing duplicate values, this will fail.
2:47:01 PM:   • A unique constraint covering the columns `[reading_source_id,schema_id]` on the table `sensor` will be added. If there are existing duplicate values, this will fail.
2:47:01 PM: Error: Use the --accept-data-loss flag to ignore the data loss warnings like yarn prisma db push --accept-data-loss
2:47:01 PM: error Command failed with exit code 1. (https://ntl.fyi/exit-code-1)
2:47:01 PM: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```


## Changes

Add `--allow-data-loss` flag to `db push` so this goes through smoothly at deploy time. 

## Testing

Can't really test this until it is merged into main (!)

