### PR TITLE
chore: skip netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   command = "sed -i \"s|process.env.DEPLOY_URL|'${DEPLOY_URL}'|g\" config.ts && yarn build"
   publish = ".next"
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF || git log -n1 | grep '\[(skip build|skip ci|ci skip|no ci|skip actions|actions skip)\]'"
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF || git log -n1 | egrep '\[(skip build|skip deploy|skip ci|ci skip|no ci|skip actions|actions skip)\]'"
 
 [[plugins]]
   package = "@netlify/plugin-nextjs"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,7 @@
 [build]
   command = "sed -i \"s|process.env.DEPLOY_URL|'${DEPLOY_URL}'|g\" config.ts && yarn build"
   publish = ".next"
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF || git log -n1 | grep '\[(skip build|skip ci|ci skip|no ci|skip actions|actions skip)\]'"
 
 [[plugins]]
   package = "@netlify/plugin-nextjs"


### PR DESCRIPTION
Retrying #118 

# Problem Context

It's hard to skip netlify builds. 

## Changes

Tell netlify to [ignore builds](https://docs.netlify.com/configure-builds/ignore-builds/) with the following tags:
- [skip build]
- [skip deploy]
Or use the default github tags for the same effect:
- [skip ci]
- [ci skip]
- [no ci]
- [skip actions]
- [actions skip]

