### PR TITLE
docs: updating netlify.toml env vars

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,6 +11,7 @@
   HUB_PROJECTUID = "Project UID of your Notehub project, e.g. app:123-456-789"
   HUB_AUTH_TOKEN = "Notehub API authentication token"
   HUB_BASE_URL = "(optional) Base URL representing the Notehub API"
+  DATABASE_URL = "URL for cloud hosted database on a platform like Amazon Web Services"
   DEBUG_CONFIG = "(optional) Debug config? If not '', log environment and config on server"
 
 [context.production]


### PR DESCRIPTION
# Problem Context

I noticed the `netlify.toml` file that helps our Netlify deployments go smoothly is missing the `DATABASE_URL` env var for cloud database platforms. Adding to help further clarify that this is a requirement for the project.

## Changes

## Screenshot (if applicable)

## Testing

Unit / integration / e2e tests?
Steps to test manually?
Any other sorts of testing notes to include?

## Any other related PRs

## Ticket(s)
